### PR TITLE
Fix メモリ上限を抑えるためメモリ管理を変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,8 +46,8 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Replace the default in-process memory cache store with a durable alternative.
-  config.cache_store = :solid_cache_store
+  # キャッシュ管理をメモリストアに変更
+  config.cache_store = :memory_store, { size: 64.megabytes }
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -25,7 +25,9 @@
 # Any libraries that use a connection pool or another resource pool should
 # be configured to provide at least as many connections as the number of
 # threads. This includes Active Record's `pool` parameter in `database.yml`.
-threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
+
+#スレッド数を2つにしてメモリを制限
+threads_count = ENV.fetch("RAILS_MAX_THREADS", 2)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.


### PR DESCRIPTION
- メモリ管理をSolid Cacheからメモリストアに変更
- pumaのスレッド数を2つに制限