### PR TITLE
Add chartkickで集計をグラフ表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,11 @@ gem "cloudinary"
 
 gem "web-push"
 
+gem "chartkick"
+
+#日付の穴埋めに使用
+gem "groupdate" 
+
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chartkick (5.2.1)
     cloudinary (2.4.4)
       faraday (>= 2.0.1, < 3.0.0)
       faraday-follow_redirects (~> 0.5)
@@ -157,6 +158,8 @@ GEM
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    groupdate (6.7.0)
+      activesupport (>= 7.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -451,12 +454,14 @@ DEPENDENCIES
   brakeman
   bundler-audit
   capybara
+  chartkick
   cloudinary
   cssbundling-rails
   debug
   devise
   devise-i18n
   factory_bot_rails
+  groupdate
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails
@@ -503,6 +508,7 @@ CHECKSUMS
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
+  chartkick (5.2.1) sha256=2848d7de87189f30f28d077eb0bbdebc8a1f0f6f81de1ded95008fe564369949
   cloudinary (2.4.4) sha256=a458a837e9ddb69b12f009496c09557f16db4244466530e02136541408d85efc
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
@@ -533,6 +539,7 @@ CHECKSUMS
   ffi (1.17.3-x86_64-linux-musl) sha256=086b221c3a68320b7564066f46fed23449a44f7a1935f1fe5a245bd89d9aea56
   fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
+  groupdate (6.7.0) sha256=beaa8d5bf3856814681914a1d4a20e77436a2214b85d0017dc2ea5c355fb6777
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   image_processing (1.14.0) sha256=754cc169c9c262980889bec6bfd325ed1dafad34f85242b5a07b60af004742fb
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/app/controllers/activity_logs_controller.rb
+++ b/app/controllers/activity_logs_controller.rb
@@ -4,14 +4,23 @@ class ActivityLogsController < ApplicationController
     activity_log_params.merge(sitting_session: current_user.sitting_sessions.active.last)
   )
 
-  if @activity_log.save
-    @activity_log.sitting_session&.completed!
-    redirect_to root_path, notice: "運動を記録しました！", status: :see_other
-  else
-    redirect_back fallback_location: root_path,
-                  alert: "記録に失敗しました: #{@activity_log.errors.full_messages.join(', ')}"
+    if @activity_log.save
+      @activity_log.sitting_session&.completed!
+      redirect_to root_path, notice: "運動を記録しました！", status: :see_other
+    else
+      redirect_back fallback_location: root_path,
+                    alert: "記録に失敗しました: #{@activity_log.errors.full_messages.join(', ')}"
+    end
   end
-end
+
+  def index
+    @daily_sitting = current_user.daily_sitting_hours(days: 7)
+    @daily_exercises = current_user.daily_exercise_counts(days: 7)
+    @activity_logs = current_user.activity_logs
+                                 .includes(:exercise)
+                                 .order(created_at: :desc)
+                                 .limit(5)
+  end
 
   private
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "chartkick/chart.js"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,25 @@ class User < ApplicationRecord
     activity_logs.today.count
   end
 
+  # 座位時間の集計
+  def daily_sitting_hours(days: 7)
+    sitting_sessions
+    .where(start_at: days.days.ago.beginning_of_day..)
+    .where(status: :completed)
+    .group_by_day(:created_at, last: days, time_zone: "Tokyo")
+    .sum(:duration)
+    .transform_keys { |date| date.strftime("%-m/%-d") }  # キーを月/日に変換
+    .transform_values { |seconds| [(seconds / 3600.0).round(1), SittingSession::SITTING_TIME_LIMIT / 3600.0].min }
+  end
+
+  #運動回数の集計
+  def daily_exercise_counts(days: 7)
+    activity_logs
+    .where(created_at: days.days.ago.beginning_of_day..)
+    .group_by_day(:created_at, last: days, time_zone: "Tokyo")
+    .count
+  end
+
   # ゲストログインの実装
   def self.guest
     find_or_create_by!(email: "guest@example.com") do |user|

--- a/app/views/activity_logs/index.html.erb
+++ b/app/views/activity_logs/index.html.erb
@@ -1,0 +1,151 @@
+<%# 背景 %>
+<div class="fixed inset-0 -z-10 overflow-hidden bg-background-dark">
+  <div class="absolute top-[-10%] left-[-10%] w-[600px] h-[600px] bg-primary/10 blur-[100px] rounded-full"></div>
+  <div class="absolute bottom-[-10%] right-[-10%] w-[600px] h-[600px] bg-primary/10 blur-[100px] rounded-full"></div>
+</div>
+
+<main class="min-h-screen w-full max-w-5xl mx-auto px-6 py-10">
+
+  <%# ページタイトル %>
+  <div class="mb-10">
+    <div class="inline-flex items-center gap-2 text-primary mb-3">
+      <span class="material-symbols-outlined text-xl">insights</span>
+      <span class="font-bold tracking-[0.2em] uppercase text-sm">Your Activity</span>
+    </div>
+    <h1 class="text-4xl font-black text-text-main tracking-tight">履歴・グラフ</h1>
+    <p class="text-text-secondary mt-2 text-base">直近7日間のあなたの活動記録</p>
+  </div>
+
+  <%# グラフエリア %>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-10">
+
+    <%# 座位時間グラフ %>
+    <div class="bg-white/40 backdrop-blur-xl border-2 border-white/60 rounded-[2.5rem] p-8 shadow-[0_8px_32px_rgba(0,0,0,0.06)]">
+      <div class="flex items-center gap-3 mb-6">
+        <div class="w-10 h-10 rounded-xl bg-primary/20 flex items-center justify-center text-primary border border-primary/30">
+          <span class="material-symbols-outlined">chair</span>
+        </div>
+        <div>
+          <h2 class="text-base font-black text-text-main">日別座位時間</h2>
+          <p class="text-xs text-text-secondary">上限 11時間</p>
+        </div>
+      </div>
+      <%= column_chart @daily_sitting,
+          max: 11,
+          colors: ["#6A9B76"],
+          suffix: "h",
+          thousands: ",",
+          round: 1,
+          height: "200px",
+          library: {
+            scales: {
+              y: { grid: { color: "rgba(0,0,0,0.05)" }, ticks: { color: "#4A5C52", font: { family: "'M PLUS Rounded 1c'" } } },
+              x: { grid: { display: false }, ticks: { color: "#4A5C52", font: { family: "'M PLUS Rounded 1c'" } } }
+            },
+            plugins: { legend: { display: false } }
+          } %>
+    </div>
+
+    <%# 運動回数グラフ %>
+    <div class="bg-white/40 backdrop-blur-xl border-2 border-white/60 rounded-[2.5rem] p-8 shadow-[0_8px_32px_rgba(0,0,0,0.06)]">
+      <div class="flex items-center gap-3 mb-6">
+        <div class="w-10 h-10 rounded-xl bg-primary/20 flex items-center justify-center text-primary border border-primary/30">
+          <span class="material-symbols-outlined">fitness_center</span>
+        </div>
+        <div>
+          <h2 class="text-base font-black text-text-main">日別運動回数</h2>
+          <p class="text-xs text-text-secondary">1日の運動セット数</p>
+        </div>
+      </div>
+      <%= area_chart @daily_exercises,
+          colors: ["#6A9B76"],
+          suffix: "回",
+          height: "200px",
+          library: {
+            scales: {
+              y: { grid: { color: "rgba(0,0,0,0.05)" }, ticks: { color: "#4A5C52", stepSize: 1, font: { family: "'M PLUS Rounded 1c'" } } },
+              x: { grid: { display: false }, ticks: { color: "#4A5C52", font: { family: "'M PLUS Rounded 1c'" } } }
+            },
+            plugins: { legend: { display: false } }
+          } %>
+    </div>
+  </div>
+
+  <%# サマリーカード %>
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-10">
+
+    <div class="bg-white/40 backdrop-blur-xl border-2 border-white/60 rounded-[2rem] p-6 shadow-[inset_0_1px_1px_rgba(255,255,255,0.8)]">
+      <p class="text-xs font-black text-text-secondary uppercase tracking-widest mb-2">今週の運動</p>
+      <p class="text-4xl font-black text-text-main"><%= @activity_logs.size %><span class="text-base font-bold text-text-secondary ml-1">回</span></p>
+    </div>
+
+    <div class="bg-white/40 backdrop-blur-xl border-2 border-white/60 rounded-[2rem] p-6 shadow-[inset_0_1px_1px_rgba(255,255,255,0.8)]">
+      <p class="text-xs font-black text-text-secondary uppercase tracking-widest mb-2">平均座位時間</p>
+      <p class="text-4xl font-black text-text-main">
+        <%= @daily_sitting.values.sum.then { |t| t.zero? ? 0 : (t / [@daily_sitting.values.count { |v| v > 0 }, 1].max).round(1) } %>
+        <span class="text-base font-bold text-text-secondary ml-1">h</span>
+      </p>
+    </div>
+
+    <div class="bg-white/40 backdrop-blur-xl border-2 border-white/60 rounded-[2rem] p-6 shadow-[inset_0_1px_1px_rgba(255,255,255,0.8)]">
+      <p class="text-xs font-black text-text-secondary uppercase tracking-widest mb-2">運動した日数</p>
+      <p class="text-4xl font-black text-text-main">
+        <%= @daily_exercises.values.count { |v| v > 0 } %>
+        <span class="text-base font-bold text-text-secondary ml-1">/ 7日</span>
+      </p>
+    </div>
+
+    <div class="bg-primary/20 backdrop-blur-xl border-2 border-primary/30 rounded-[2rem] p-6 shadow-[inset_0_1px_1px_rgba(255,255,255,0.8)]">
+      <p class="text-xs font-black text-primary uppercase tracking-widest mb-2">今日の運動</p>
+      <p class="text-4xl font-black text-text-main">
+        <%= current_user.today_exercise_count %>
+        <span class="text-base font-bold text-text-secondary ml-1">回</span>
+      </p>
+    </div>
+
+  </div>
+
+  <%# 運動履歴リスト %>
+  <div class="bg-white/40 backdrop-blur-xl border-2 border-white/60 rounded-[2.5rem] p-8 shadow-[0_8px_32px_rgba(0,0,0,0.06)]">
+    <div class="flex items-center gap-3 mb-6">
+      <div class="w-10 h-10 rounded-xl bg-primary/20 flex items-center justify-center text-primary border border-primary/30">
+        <span class="material-symbols-outlined">history</span>
+      </div>
+      <h2 class="text-base font-black text-text-main">運動履歴</h2>
+    </div>
+
+    <% if @activity_logs.empty? %>
+      <div class="text-center py-16 text-text-secondary">
+        <span class="material-symbols-outlined text-5xl mb-4 block text-primary/40">fitness_center</span>
+        <p class="font-bold text-lg">まだ記録がありません</p>
+        <p class="text-sm mt-1">運動を完了すると履歴が表示されます</p>
+      </div>
+    <% else %>
+      <div class="space-y-3">
+        <% @activity_logs.each do |log| %>
+          <div class="flex items-center justify-between p-5 bg-white/50 border border-white/60 rounded-2xl shadow-[inset_0_1px_1px_rgba(255,255,255,0.8)] hover:bg-white/70 transition-all">
+            <div class="flex items-center gap-4">
+              <div class="w-10 h-10 rounded-xl bg-primary/20 flex items-center justify-center text-primary border border-primary/20 shrink-0">
+                <span class="material-symbols-outlined text-xl">
+                  <%= log.exercise.category == "walk" ? "directions_walk" : log.exercise.category == "stretch" ? "self_improvement" : "fitness_center" %>
+                </span>
+              </div>
+              <div>
+                <p class="font-bold text-text-main text-base"><%= log.exercise.name %></p>
+                <p class="text-xs text-text-secondary mt-0.5">
+                  <span class="inline-block px-2 py-0.5 bg-primary/10 text-primary rounded-full font-bold border border-primary/20">
+                    <%= { "stretch" => "ストレッチ", "training" => "トレーニング", "walk" => "ウォーキング" }[log.exercise.category] %>
+                  </span>
+                </p>
+              </div>
+            </div>
+            <p class="text-sm text-text-secondary font-medium shrink-0">
+              <%= log.created_at.in_time_zone("Tokyo").strftime("%m/%d %H:%M") %>
+            </p>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
+</main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,6 +52,12 @@
         <div class="hidden lg:flex items-center gap-6">
           <% if user_signed_in? %>
             <%# ログイン後：ユーザーメニュー %>
+            <%# 履歴リンクを追加 %>
+            <%= link_to activity_logs_path,
+                class: "flex items-center gap-2 text-sm font-bold text-text-secondary hover:text-primary transition-colors" do %>
+                <span class="material-symbols-outlined text-xl">bar_chart</span>
+                履歴
+             <% end %>
             <div class="relative" data-controller="dropdown" data-action="click@window->dropdown#hide">
               <button
                 data-action="click->dropdown#toggle"

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,7 +17,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 10 } %>
   host: db
   username: postgres
   password: password

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,16 +8,16 @@ Rails.application.routes.draw do
     root "static_pages#top"
   end
 
-  resources :sitting_sessions, only: [ :new, :create, :show ] do
+  resources :sitting_sessions, only: %i[new create show ] do
     collection do
       post :subscribe
       patch :finish_current
     end
   end
 
-  resources :exercises, only: [ :index, :show ]
+  resources :exercises, only: %i[index show ]
 
-  resources :activity_logs, only: [ :create ]
+  resources :activity_logs, only: %i[create index ]
 
   devise_for :users, controllers: {
     registrations: "users/registrations"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.23",
     "@tailwindcss/cli": "^4.1.18",
+    "chart.js": "^4.5.1",
+    "chartkick": "^5.0.1",
     "tailwindcss": "^4.1.18"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -206,6 +206,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@kurkle/color@^0.3.0":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.4.tgz#4d4ff677e1609214fc71c580125ddddd86abcabf"
+  integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
+
 "@napi-rs/wasm-runtime@^1.1.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz#c3705ab549d176b8dc5172723d6156c3dc426af2"
@@ -426,6 +431,32 @@
   integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
   dependencies:
     tslib "^2.4.0"
+
+chart.js@4, chart.js@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.5.1.tgz#19dd1a9a386a3f6397691672231cb5fc9c052c35"
+  integrity sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
+
+chartjs-adapter-date-fns@>=3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-3.0.0.tgz#c25f63c7f317c1f96f9a7c44bd45eeedb8a478e5"
+  integrity sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==
+
+chartkick@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/chartkick/-/chartkick-5.0.1.tgz#f557ff8560f974343dc65c7fc34ce1e8326d8ee7"
+  integrity sha512-4F3tWI3eBQgnjCYZIZ+fHOaJuNyxeyhDE2Tm+voOWB19hDjSJceys/spzN52DOn8bWepNESGXvPVTGU1jeFsbA==
+  optionalDependencies:
+    chart.js "4"
+    chartjs-adapter-date-fns ">=3"
+    date-fns ">=2"
+
+date-fns@>=2:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
 detect-libc@^2.0.3:
   version "2.1.2"


### PR DESCRIPTION
close #116 
- 座位時間と運動回数を1週間分表示
- 履歴メニューを作成しヘッダー表示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * アクティビティ履歴ダッシュボードページを追加しました。日次の運動時間と運動回数をチャートで可視化します
  * ナビゲーションに履歴ページへのリンクを追加しました
  * 週間統計情報（総運動時間、平均座席時間、運動日数など）をサマリーカードで表示するようになりました

* **その他**
  * データベース接続数設定を更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->