### PR TITLE
メモリクラッシュ対応のためにscheduler無効化

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -27,7 +27,7 @@
 # threads. This includes Active Record's `pool` parameter in `database.yml`.
 
 # スレッド数を2つにしてメモリを制限
-threads_count = ENV.fetch("RAILS_MAX_THREADS", 2)
+threads_count = ENV.fetch("RAILS_MAX_THREADS", 1)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -1,7 +1,7 @@
 default: &default
   dispatchers:
     - polling_interval: 10
-      batch_size: 100
+      batch_size: 10
   workers:
     - queues: "*"
       threads: 1

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -10,6 +10,6 @@
 #     schedule: at 5am every day
 
 production:
-  clear_solid_queue_finished_jobs:
-    command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
-    schedule: every hour at minute 12
+  #clear_solid_queue_finished_jobs:
+  #command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
+  #schedule: every hour at minute 12


### PR DESCRIPTION
- schedulerの無効化
- batch_sizeの縮小
- pumaスレッドをを2→1に


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * スレッドプール設定を調整し、1プロセスあたりのスレッド数を削減
  * キューバッチサイズを削減し、ポーリングディスパッチャーの処理単位を縮小
  * 定期実行ジョブの完了データ自動クリーンアップ機能を無効化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->