### PR TITLE
fixパスワードリセット用にsmtpを修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,17 +57,16 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  # renderでパスワードリセットをgmailで送る
+  # resendでパスワードリセットを送る
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.default_url_options = { host: "https://istanding-bi2i.onrender.com" }
+  config.action_mailer.default_url_options = { host: "istanding.jp", protocol: "https" }
 
   config.action_mailer.smtp_settings = {
-    address:              "smtp.gmail.com",
+    address:              "smtp.resend.com",
     port:                 465,
-    domain:               "gmail.com",
-    user_name:            ENV["GMAIL_USER"],
-    password:             ENV["GMAIL_PASSWORD"],
+    user_name:            "resend",
+    password:             ENV["RESEND_API_KEY"],
     authentication:       "plain",
     tls:                  true,
     enable_starttls_auto: false


### PR DESCRIPTION
## なぜ必要か
Deviseでパスワードリセットを実装するため
## ブランチ名
```
feature/163/devise_reset_password
```
## 必要なこと
- resendにてAPI経由でメール送信
- ドメインのDNSをresendへむける
- produciton.rbのsmtpを修正


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * パスワードリセットメール配信システムの基盤を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->