### PR TITLE
refactor reset_currentをdestroyメソッドに集約

### DIFF
--- a/app/controllers/sitting_sessions_controller.rb
+++ b/app/controllers/sitting_sessions_controller.rb
@@ -22,6 +22,14 @@ class SittingSessionsController < ApplicationController
     end
   end
 
+  # リセットボタン用
+  def destroy
+    @sitting_session = current_user.sitting_sessions.active.last
+    return head :not_found unless @sitting_session
+
+    @sitting_session.destroy!
+  end
+
   # タイマー終了時にduration更新とステータス変更
   def finish_current
     @sitting_session = current_user.sitting_sessions.active.last
@@ -41,14 +49,6 @@ class SittingSessionsController < ApplicationController
     respond_to do |format|
       format.turbo_stream
     end
-  end
-
-  # リセットボタン用
-  def reset_current
-    @sitting_session = current_user.sitting_sessions.active.last
-    return head :not_found unless @sitting_session
-
-    @sitting_session.cancelled!
   end
 
   def subscribe

--- a/app/javascript/controllers/timer_controller.js
+++ b/app/javascript/controllers/timer_controller.js
@@ -125,7 +125,7 @@ export default class extends Controller {
         this.clearModalUI()
         this.updateCircle()
 
-        await fetch("/sitting_sessions/reset_current", {
+        await fetch(`/sitting_sessions/${this.sessionIdValue}`, {
             method: "DELETE",
             headers: {
                 "Content-Type": "application/json",

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,6 +1,7 @@
 <div class="min-h-screen bg-background-dark p-4 md:p-6 overflow-x-hidden"
     data-controller="notification timer"
-    data-notification-public-key-value="<%= Rails.application.credentials.dig(:webpush, :public_key) %>">
+    data-notification-public-key-value="<%= Rails.application.credentials.dig(:webpush, :public_key) %>"
+    data-timer-session-id-value="<%= current_user.sitting_sessions.active.last&.id %>">
 
   <div class="max-w-6xl mx-auto flex flex-col lg:flex-row items-center lg:items-center justify-center gap-8 lg:gap-16 transition-all duration-500">
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,11 +15,10 @@ Rails.application.routes.draw do
     root "static_pages#top"
   end
 
-  resources :sitting_sessions, only: %i[new create show ] do
+  resources :sitting_sessions, only: %i[new create show destroy] do
     collection do
       post :subscribe
       patch :finish_current
-      delete :reset_current
     end
   end
 
@@ -44,7 +43,7 @@ Rails.application.routes.draw do
   get "privacy", to: "pages#privacy"
 
   # OGP
-  get "ogp/:index", to: "ogp_images#show", as: :ogp_image, constraints: { text: /[^\/]+/ } # スラッシュ以外は許可
+  get "ogp/:index", to: "ogp_images#show", as: :ogp_image
 
   # PWA
   get "/manifest.json", to: "rails/pwa#manifest", as: :pwa_manifest


### PR DESCRIPTION
## なぜ必要か
Rails wayに則り、destroyで処理が可能なため
## ブランチ名
```
refactor/reset_current
```
## 必要なこと
- route destroyを追加
- viewからidを渡す
- controllerにおいてreset_currentメソッドをdestroyに移行
## このissueで実装しないもの
enumのcancelledは不要になるが、可動性とリファクタリングコストを考慮してそのまま使用する


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善・リファクタリング**
  * セッション削除機能の内部処理を最適化しました
  * セッション管理システムにおいて、より効率的で一貫性のある処理フローに変更しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->