### PR TITLE
fix activity log migration error

### DIFF
--- a/db/migrate/20260401024910_remove_active_from_exercises.rb
+++ b/db/migrate/20260401024910_remove_active_from_exercises.rb
@@ -1,5 +1,7 @@
 class RemoveActiveFromExercises < ActiveRecord::Migration[8.1]
   def change
+    # column_exists? を使って、カラムがある時だけ削除するようにガードを入れる
+    if column_exists?(:exercises, :active)
     remove_column :exercises, :active, :boolean
   end
 end

--- a/db/migrate/20260401025018_add_active_to_exercises.rb
+++ b/db/migrate/20260401025018_add_active_to_exercises.rb
@@ -1,5 +1,8 @@
 class AddActiveToExercises < ActiveRecord::Migration[8.1]
   def change
-    add_column :exercises, :active, :boolean, default: true, null: false
+    # カラムがまだ存在しない時だけ追加する
+    unless column_exists?(:exercises, :active)
+      add_column :exercises, :active, :boolean, default: true, null: false
+    end
   end
 end


### PR DESCRIPTION
## なぜ必要か
migrationの削除と追加の経緯によりローカルと本番での差が生じデプロイエラーになってしまったため
## ブランチ名
```
fix/activity_log_migration_error
```
## 必要なこと
migrationファイルに条件分岐を追加し、本番環境に対応


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* データベースマイグレーション実行時の信頼性を向上させ、複数の環境での実行時に発生する可能性のあった問題を防止するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->