### PR TITLE
fix ランダム表示のロジック修正

### DIFF
--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -20,7 +20,7 @@ class ExercisesController < ApplicationController
   end
 
   def random
-    @exercise = Exercise.order("RANDOM()").first
+    @exercise = Exercise.active.order("RANDOM()").first
     redirect_to exercise_path(@exercise)
   end
 end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -8,6 +8,8 @@ class TopController < ApplicationController
     @exercise_count = current_user.today_exercise_count
     # タイマーにnotify_atを渡すための変数
     @active_session = current_user.sitting_sessions.active.last
+    # 自由な運動を記録するためにotherカテゴリのexercise_idを渡す
+    @other_exercise = Exercise.find_by(category: :other)
 
     if params[:reopen_modal] == "true"
       @exercises = Exercise.order("RANDOM()").limit(3)


### PR DESCRIPTION
## なぜ必要か
exercise/randomからリンクするとactiveでないexerciseも含まれていたため
exercise/randomからtop/indexに遷移すると@other_exerciseがnilとなり500エラーが生じたため
## ブランチ
```
fix/random_exercises_logic
```
## 必要なこと
- randomメソッドの修正
- @other_exerciseをtop/indexにも追加
## このissueで実装しないもの
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 「その他」カテゴリーのエクササイズを表示する機能を追加しました。

* **改善**
  * ランダムに選択されるエクササイズの対象を有効なエクササイズのみに限定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->