### PR TITLE
fix　OGPからアクセスする時、未ログイン時はトップにリダイレクト

### DIFF
--- a/app/controllers/activity_logs_controller.rb
+++ b/app/controllers/activity_logs_controller.rb
@@ -1,4 +1,6 @@
 class ActivityLogsController < ApplicationController
+  before_action :require_login
+
   def new
     @exercise = Exercise.find(params[:exercise_id])
     @activity_log = current_user.activity_logs.build(exercise: @exercise)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,4 +25,10 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     root_path
   end
+
+  def require_login
+    unless user_signed_in?
+      redirect_to root_path
+    end
+  end
 end


### PR DESCRIPTION
## なぜ必要か
xで共有された際に、未ログインのまま「完了して戻る」を押すと500エラーとなる
## ブランチ名
```
hotfix/share_link_error
```
## 必要なこと
deviseのbefore_actionでリダイレクト先をトップに変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **セキュリティ改善**
  * アクティビティログセクションのすべての機能へのアクセスにログイン認証が必須となりました。認証されていないユーザーはホームページにリダイレクトされます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->