### PR TITLE
add timer 1min feature

### DIFF
--- a/app/models/sitting_session.rb
+++ b/app/models/sitting_session.rb
@@ -1,6 +1,6 @@
 class SittingSession < ApplicationRecord
   # タイマーの時間選択肢
-  SETTING_DURATIONS = [ 30, 45, 60, 90, 120 ].freeze
+  SETTING_DURATIONS = [ 30, 45, 60, 90, 1 ].freeze
   # 一日の座位時間上限(11時間を秒に換算)
   SITTING_TIME_LIMIT = 11 * 60 * 60
 


### PR DESCRIPTION
## なぜ必要か
イベント用に短い時間のタイマーを追加するため
## ブランチ名
```
feature/test-timer-1min
```
## 必要なこと
SETTING_DURATIONS 定数に1を追加



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* セッション時間の設定オプションが更新されました。利用可能な最大時間設定が変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->