### PR TITLE
Fix/notification error

### DIFF
--- a/app/controllers/sitting_sessions_controller.rb
+++ b/app/controllers/sitting_sessions_controller.rb
@@ -16,9 +16,9 @@ class SittingSessionsController < ApplicationController
       # タイマー終了時に通知jobを予約する
       job = SendNotificationJob.set(wait_until: @sitting_session.notify_at)
                           .perform_later(@sitting_session.id)
-      Rails.logger.info "=== job_id: #{job.job_id} ==="
+                          
       @sitting_session.update(job_id: job.job_id)
-      Rails.logger.info "=== saved job_id: #{@sitting_session.reload.job_id} ==="
+     
       # notify_atをJSに渡す
       render json: { notify_at: @sitting_session.notify_at.iso8601 }
     end

--- a/app/controllers/sitting_sessions_controller.rb
+++ b/app/controllers/sitting_sessions_controller.rb
@@ -16,9 +16,9 @@ class SittingSessionsController < ApplicationController
       # タイマー終了時に通知jobを予約する
       job = SendNotificationJob.set(wait_until: @sitting_session.notify_at)
                           .perform_later(@sitting_session.id)
-                          
+
       @sitting_session.update(job_id: job.job_id)
-     
+
       # notify_atをJSに渡す
       render json: { notify_at: @sitting_session.notify_at.iso8601 }
     end

--- a/app/controllers/sitting_sessions_controller.rb
+++ b/app/controllers/sitting_sessions_controller.rb
@@ -14,8 +14,11 @@ class SittingSessionsController < ApplicationController
     if @sitting_session.save
 
       # タイマー終了時に通知jobを予約する
-      SendNotificationJob.set(wait_until: @sitting_session.notify_at)
+      job = SendNotificationJob.set(wait_until: @sitting_session.notify_at)
                           .perform_later(@sitting_session.id)
+      Rails.logger.info "=== job_id: #{job.job_id} ==="
+      @sitting_session.update(job_id: job.job_id)
+      Rails.logger.info "=== saved job_id: #{@sitting_session.reload.job_id} ==="
       # notify_atをJSに渡す
       render json: { notify_at: @sitting_session.notify_at.iso8601 }
     end
@@ -26,8 +29,11 @@ class SittingSessionsController < ApplicationController
     @sitting_session = current_user.sitting_sessions.active.last
     return head :not_found unless @sitting_session
 
-    # 休憩するで早期に終了したらdurationを更新
+    # 休憩するで早期に終了したらdurationを更新し、通知もキャンセル
     @sitting_session.update(duration: (Time.current - @sitting_session.start_at).to_i)
+
+    job = SolidQueue::Job.find_by(active_job_id: @sitting_session.job_id)
+    job&.discard if params[:manual].present?
 
     # 自由な運動を記録するためにotherカテゴリのexercise_idを渡す
     @other_exercise = Exercise.find_by(category: :other)
@@ -50,6 +56,7 @@ class SittingSessionsController < ApplicationController
     @sitting_session = current_user.sitting_sessions.active.last
     return head :not_found unless @sitting_session
 
+    SolidQueue::Job.find_by(active_job_id: @sitting_session.job_id)&.discard
     @sitting_session.cancelled!
   end
 

--- a/app/javascript/controllers/timer_controller.js
+++ b/app/javascript/controllers/timer_controller.js
@@ -48,11 +48,11 @@ export default class extends Controller {
         }
 
         // パターン2: 既存タブがあった場合（postMessage）
-        navigator.serviceWorker.addEventListener('message', (event) => {
-            if (event.data?.type === 'SHOW_MODAL') {
-                this.finish()
-            }
-        })
+        // navigator.serviceWorker.addEventListener('message', (event) => {
+        //     if (event.data?.type === 'SHOW_MODAL') {
+        //         this.finish()
+        //     }
+        // })
     }
 
     setTime(event) {

--- a/app/javascript/controllers/timer_controller.js
+++ b/app/javascript/controllers/timer_controller.js
@@ -199,7 +199,8 @@ export default class extends Controller {
         }, AUTO_CLOSE_MS)
     }
 
-    async finish() {
+    async finish(event) {
+        const manual = event?.params?.manual ?? false
         this.stop()
         this.clearAutoCloseTimer()
         this.remainingTime = 0
@@ -228,7 +229,8 @@ export default class extends Controller {
                 "Accept": "text/vnd.turbo-stream.html",
                 "Content-Type": "application/json",
                 "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
-            }
+            },
+            body: JSON.stringify({ manual: manual })
         })
 
         if (response.ok) {

--- a/app/jobs/send_notification_job.rb
+++ b/app/jobs/send_notification_job.rb
@@ -8,8 +8,8 @@ class SendNotificationJob < ApplicationJob
 
     return if session.nil?
 
-    # statusがactiveの時だけ通知
-    return unless session&.active?
+    # sessionが存在するときだけ通知
+    return unless session
 
     user = session.user
     return if user.endpoint.blank?

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -66,6 +66,7 @@
         <button type="button"
           data-timer-target="runningButton"
           data-action="click->timer#finish"
+          data-timer-manual-param="true"
           class="py-4 px-12 rounded-2xl text-lg font-bold tracking-widest bg-primary/20 text-text-main border border-primary/50 shadow-lg hover:bg-primary/30 transition-all active:scale-95 cursor-pointer hidden w-full max-w-[240px]">
           休憩する
         </button>

--- a/db/migrate/20260423213053_add_job_to_sitting_sessions.rb
+++ b/db/migrate/20260423213053_add_job_to_sitting_sessions.rb
@@ -1,0 +1,5 @@
+class AddJobToSittingSessions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :sitting_sessions, :job_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_01_025018) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_23_213053) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -69,6 +69,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_01_025018) do
   create_table "sitting_sessions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "duration"
+    t.string "job_id"
     t.boolean "notified"
     t.datetime "notify_at"
     t.datetime "start_at"


### PR DESCRIPTION
## なぜ必要か
通知が来ない状態になっていたため要修正
## ブランチ名
```
fix/notification_error
```
## 必要なこと
- sitting_sesssionにjob_idカラムを追加
- 「休憩する」ボタンを押し際にparam[:manual]をJSより送信
- manualがある場合はバックグラウンドジョブをキャンセル
- 通常の終了の場合、modalクリック時のAddEventListnerを削除
## このissueで実装しないもの
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能とバグ修正

* **バグ修正**
  * 休憩セッションを手動で終了した場合、スケジュール済みの通知がキャンセルされるようになりました。これにより、セッション終了後に誤った通知を受け取ることはなくなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->