### PR TITLE
fix タイマーの1minを120分に戻す

### DIFF
--- a/app/models/sitting_session.rb
+++ b/app/models/sitting_session.rb
@@ -1,6 +1,6 @@
 class SittingSession < ApplicationRecord
   # タイマーの時間選択肢
-  SETTING_DURATIONS = [ 30, 45, 60, 90, 1 ].freeze
+  SETTING_DURATIONS = [ 30, 45, 60, 90, 120 ].freeze
   # 一日の座位時間上限(11時間を秒に換算)
   SITTING_TIME_LIMIT = 11 * 60 * 60
 


### PR DESCRIPTION
## なぜ必要か
テスト公開が終了したため
## ブランチ名
```
fix/timer_1min
```
## 必要なこと
SETTING_DURATIONS変数の修正
## このissueで実装しないもの
特になし