### PR TITLE
fix solidqueueの設定削除とタイマーロジック調整

### DIFF
--- a/app/controllers/sitting_sessions_controller.rb
+++ b/app/controllers/sitting_sessions_controller.rb
@@ -32,8 +32,10 @@ class SittingSessionsController < ApplicationController
     # 休憩するで早期に終了したらdurationを更新し、通知もキャンセル
     @sitting_session.update(duration: (Time.current - @sitting_session.start_at).to_i)
 
-    job = SolidQueue::Job.find_by(active_job_id: @sitting_session.job_id)
-    job&.discard if params[:manual].present?
+    # 休憩するボタンで終了した時に通知を送らないようにする
+    if params[:manual] == "true" || params[:manual] == true
+      @sitting_session.completed!
+    end
 
     # 自由な運動を記録するためにotherカテゴリのexercise_idを渡す
     @other_exercise = Exercise.find_by(category: :other)
@@ -41,8 +43,7 @@ class SittingSessionsController < ApplicationController
     # ダメージを計算
     current_user.take_damage(@sitting_session.duration)
 
-    # 休憩するボタンで終了した時に通知を送らないようにする
-    @sitting_session.completed!
+    
 
     # N+1を防ぐために一回のアクセスで3つの画像を取得
     @exercises = Exercise.order("RANDOM()").limit(3).includes(image_attachment: :blob)
@@ -56,8 +57,8 @@ class SittingSessionsController < ApplicationController
     @sitting_session = current_user.sitting_sessions.active.last
     return head :not_found unless @sitting_session
 
-    SolidQueue::Job.find_by(active_job_id: @sitting_session.job_id)&.discard
     @sitting_session.cancelled!
+    head :ok
   end
 
   def subscribe

--- a/app/controllers/sitting_sessions_controller.rb
+++ b/app/controllers/sitting_sessions_controller.rb
@@ -43,7 +43,7 @@ class SittingSessionsController < ApplicationController
     # ダメージを計算
     current_user.take_damage(@sitting_session.duration)
 
-    
+
 
     # N+1を防ぐために一回のアクセスで3つの画像を取得
     @exercises = Exercise.order("RANDOM()").limit(3).includes(image_attachment: :blob)

--- a/app/javascript/controllers/timer_controller.js
+++ b/app/javascript/controllers/timer_controller.js
@@ -32,6 +32,13 @@ export default class extends Controller {
             const notifyAt = new Date(this.notifyAtValue)
             this.remainingTime = Math.floor((notifyAt - new Date()) / 1000)
 
+            // 古いタイマーが残っている場合は処理を抜ける
+            if (this.remainingTime <= 0) {
+                this.remainingTime = 0
+                this.updateDisplay()
+                return
+            }
+
             this.startButtonTarget.classList.add("hidden")
             this.runningButtonTargets.forEach(button => button.classList.remove("hidden"))
 
@@ -40,19 +47,12 @@ export default class extends Controller {
             this.runTimer()
         }
 
-        // パターン1: 新規タブで開いた場合（URLパラメータ）
+        // 新規タブで開いた場合（URLパラメータ）
         const params = new URLSearchParams(window.location.search)
         if (params.get('session_id')) {
             window.history.replaceState({}, document.title, window.location.pathname)
             this.finish()
         }
-
-        // パターン2: 既存タブがあった場合（postMessage）
-        // navigator.serviceWorker.addEventListener('message', (event) => {
-        //     if (event.data?.type === 'SHOW_MODAL') {
-        //         this.finish()
-        //     }
-        // })
     }
 
     setTime(event) {

--- a/app/jobs/send_notification_job.rb
+++ b/app/jobs/send_notification_job.rb
@@ -8,8 +8,8 @@ class SendNotificationJob < ApplicationJob
 
     return if session.nil?
 
-    # sessionが存在するときだけ通知
-    return unless session
+    # 手動終了(completed)やリセット(cancelled)のときは通知をスキップ
+    return if session.completed? || session.cancelled?
 
     user = session.user
     return if user.endpoint.blank?

--- a/compose.yml
+++ b/compose.yml
@@ -27,6 +27,7 @@ services:
       - node_modules:/myapp/node_modules
     environment:
       TZ: Asia/Tokyo
+      REDIS_URL: "rediss://default:gQAAAAAAAU8rAAIgcDEwNWI3YWE1NmZjMjg0NmM2YTE5YTExNTZjMjg1MGU5Ng@mature-woodcock-85803.upstash.io:6379"
     ports:
       - "3000:3000"
     depends_on:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
 
-  config.active_job.queue_adapter = :solid_queue
+  config.active_job.queue_adapter = :sidekiq
   # Highlight code that triggered redirect in logs.
   config.action_dispatch.verbose_redirect_logs = true
 


### PR DESCRIPTION
## なぜ必要か
solidqueueの設定が残っており、タイマーのjob管理にエラーが発生したため
## ブランチ名
```
fix/delete_solidqueue_setting
```
## 必要なこと
- solidqueueによるjobのdiscardを削除
- jobのガート節にてステータス別の早期リターン
- リロードアクション時の挙動を調整