### PR TITLE
fix ローカル用にredisを設定

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -14,6 +14,17 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
   web:
     build:
       context: .
@@ -33,7 +44,10 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
 volumes:
   bundle_data:
   postgresql_data:
   node_modules:
+  redis_data:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -83,4 +83,6 @@ Rails.application.configure do
   config.hosts << "nontolerably-unequiangular-bernardine.ngrok-free.dev"
 
   routes.default_url_options = { host: "nontolerably-unequiangular-bernardine.ngrok-free.dev", protocol: "https" }
+
+  ENV["REDIS_URL"] = "redis://redis:6379"
 end


### PR DESCRIPTION
## なぜ必要か
ローカル検証用にredisを立ち上げるため
## ブランチ名
```
fix/redis_environment_setting
```
## 必要なこと
- compose.ymlにredisを追加
- 開発環境ではredisをローカルで利用
