### PR TITLE
remove memory_logger.rbの削除

### DIFF
--- a/config/initializers/memory_logger.rb
+++ b/config/initializers/memory_logger.rb
@@ -1,9 +1,0 @@
-if Rails.env.production?
-  Thread.new do
-    loop do
-      memory_mb = `cat /proc/self/status | grep VmRSS`.match(/(\d+)/)[1].to_i / 1024
-      Rails.logger.info "[MemoryMonitor] RSS: #{memory_mb} MB"
-      sleep 60 # 1分ごとに出力
-    end
-  end
-end


### PR DESCRIPTION
## なぜ必要か
メモリトラブル解消により本番ログにメモリ消費量の表示が不要となったため
## ブランチ名
```
remove/memory_logger
```
## 必要なこと
memory_logger.rbの削除


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 定期メモリ使用量ログの出力機能を削除しました。システムの定期的なメモリ監視ログは出力されなくなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->