### PR TITLE
fix 通知タイミングの調整

### DIFF
--- a/app/javascript/controllers/timer_controller.js
+++ b/app/javascript/controllers/timer_controller.js
@@ -133,7 +133,7 @@ export default class extends Controller {
 
             if (this.remainingTime <= 0) {
                 this.stop()
-                this.finish()
+                setTimeout(() => { this.finish() }, 1000)
             }
         }, 1000)
     }


### PR DESCRIPTION
## なぜ必要か
通知前にセッション終了となり通知が来ない不具合が出たため
## ブランチ名
```
fix/adjust_notification_timing
```
## 必要なこと
- タイマー終了時のjavascript内finish呼び出しをsetTimeoutで遅延



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * タイマー機能が改善されました。時間切れを検出した際の完了処理に1秒のタイムアウトディレイが追加されました。これにより、より堅牢で安定した動作が実現され、ユーザー体験が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->