### PR TITLE
fix statusカラムのmigrateファイルを修正

### DIFF
--- a/db/migrate/20260620045843_add_status_to_sitting_sessions.rb
+++ b/db/migrate/20260620045843_add_status_to_sitting_sessions.rb
@@ -1,5 +1,7 @@
 class AddStatusToSittingSessions < ActiveRecord::Migration[8.1]
   def change
+    # statusカラムの存在により本番エラーを防ぐため、カラムが存在する場合は追加しないようにする
+    return if column_exists?(:sitting_sessions, :status)
     add_column :sitting_sessions, :status, :integer, default: 0, null: false
   end
 end


### PR DESCRIPTION
## なぜ必要か
本番デプロイにてmigrateファイルエラーが出たため
## ブランチ名
```
fix/adjust_notification_timing
```
## 必要なこと
カラムが存在する場合は追加しない分岐を追加
